### PR TITLE
Add error handling states to resource list tables

### DIFF
--- a/apps/admin/src/pages/resource-list.tsx
+++ b/apps/admin/src/pages/resource-list.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
-import { Table, Typography } from "antd";
+import { useEffect, useMemo } from "react";
+import { Result, Spin, Table, Typography } from "antd";
+import type { AxiosError } from "axios";
 import type { ColumnsType } from "antd/es/table";
 import { List, useTable } from "@refinedev/antd";
 import { useResource } from "@refinedev/core";
@@ -18,6 +19,89 @@ export const ResourceList = () => {
       pageSize: 10,
     },
   });
+
+  const {
+    data,
+    isError = false,
+    isFetched = false,
+    isLoading = false,
+    error,
+  } = tableQueryResult ?? {};
+
+  const records = (data?.data as unknown[]) ?? [];
+  const hasRecords = records.length > 0;
+  const showLoadingState = isLoading && !hasRecords;
+  const isEmpty = !showLoadingState && isFetched && !isError && !hasRecords;
+
+  useEffect(() => {
+    if (isError) {
+      console.error(`[ResourceList] Failed to fetch ${resource?.name ?? "resource"} data`, error);
+    }
+  }, [error, isError, resource?.name]);
+
+  const errorResult = useMemo(() => {
+    if (!isError) {
+      return null;
+    }
+
+    const axiosError = error as unknown as AxiosError<{
+      message?: string;
+      error?: string;
+    }>;
+    const httpError = (error as { statusCode?: number; status?: number; message?: string }) ?? {};
+    const statusCode = axiosError?.response?.status ?? httpError.statusCode ?? httpError.status;
+    const responseMessage =
+      axiosError?.response?.data?.message ??
+      axiosError?.response?.data?.error ??
+      axiosError?.message ??
+      httpError.message ??
+      (typeof axiosError === "object" && axiosError !== null
+        ? (axiosError as { message?: string }).message
+        : undefined);
+
+    if (statusCode === 401) {
+      return (
+        <Result
+          status="403"
+          title="Tidak ada otorisasi"
+          subTitle={
+            responseMessage ??
+            "Token akses tidak valid atau telah kedaluwarsa. Silakan login kembali."
+          }
+          extra={<Typography.Text type="secondary">Status kode: 401</Typography.Text>}
+        />
+      );
+    }
+
+    if (statusCode === 404) {
+      return (
+        <Result
+          status="404"
+          title="Data tidak ditemukan"
+          subTitle={
+            responseMessage ?? "Endpoint atau data yang diminta tidak tersedia pada server."
+          }
+          extra={<Typography.Text type="secondary">Status kode: 404</Typography.Text>}
+        />
+      );
+    }
+
+    const subtitle =
+      responseMessage ?? "Terjadi kesalahan saat mengambil data dari server. Silakan coba lagi.";
+
+    return (
+      <Result
+        status="error"
+        title="Gagal mengambil data"
+        subTitle={subtitle}
+        extra={
+          statusCode ? (
+            <Typography.Text type="secondary">Status kode: {statusCode}</Typography.Text>
+          ) : undefined
+        }
+      />
+    );
+  }, [error, isError]);
 
   const columns = useMemo<ColumnsType<Record<string, unknown>>>(() => {
     const sample = (tableQueryResult?.data?.data ?? tableProps?.dataSource ?? []).find(
@@ -56,11 +140,40 @@ export const ResourceList = () => {
 
   return (
     <List title={resource?.meta?.label ?? resource?.label ?? resource?.name}>
-      <Table
-        {...tableProps}
-        columns={columns}
-        rowKey={(record) => (record as { id?: string | number }).id ?? JSON.stringify(record)}
-      />
+      {showLoadingState && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 240,
+            gap: 12,
+            flexDirection: "column",
+          }}
+        >
+          <Spin size="large" />
+          <Typography.Text>Memuat data...</Typography.Text>
+        </div>
+      )}
+
+      {errorResult}
+
+      {isEmpty && (
+        <Result
+          status="info"
+          title="Data belum tersedia"
+          subTitle="Tidak ada data yang bisa ditampilkan untuk resource ini."
+        />
+      )}
+
+      {!showLoadingState && !isError && !isEmpty && (
+        <Table
+          {...tableProps}
+          loading={isLoading || tableProps?.loading}
+          columns={columns}
+          rowKey={(record) => (record as { id?: string | number }).id ?? JSON.stringify(record)}
+        />
+      )}
     </List>
   );
 };


### PR DESCRIPTION
## Summary
- add explicit loading, empty, and error states to the generic resource list view
- surface unauthorized and missing data messages to aid debugging when API responses fail

## Testing
- pnpm --filter @apps/admin build *(fails: shared package dist missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3745936708326ac38fc5574defd67